### PR TITLE
This is my modification for issue #13

### DIFF
--- a/log.c
+++ b/log.c
@@ -71,6 +71,7 @@ void log_daily_rotate(int _hour, int _min, int _reqs_precheck) {
 	setting.hour  = _hour;
 	setting.min   = _min;
 	setting.preck = _reqs_precheck;
+    setting.cnt = 0;
 }
 
 
@@ -94,6 +95,7 @@ int logrotate() {
 		if(rename(setting.filename, newName)) {
 			printf("checking[%d]\n", t->tm_min);
 			perror(newName);
+            while(!cas_free);
 			return -1;
 		}
 		free(newName);
@@ -157,7 +159,8 @@ void logger_impl(int level, const char* file, int line, const char* fmt, ...) {
 	char _buf[2048];
 	memset(_buf,0,2048);
 
-	if (CHECK_FLAG(setting.options, LOG_DAILY_ROTATE) && setting.cnt%setting.preck== 0) {
+	if (CHECK_FLAG(setting.options, LOG_DAILY_ROTATE) &&
+            setting.cnt != 0 && setting.cnt%setting.preck== 0) {
 		logrotate();
 	}
 

--- a/log.h
+++ b/log.h
@@ -49,6 +49,7 @@ void log_daily_rotate(int _hour, int _min, int _reqs_precheck);
 void logger_impl(int level, const char* file, int line, const char* fmt, ...);
 
 
+#define DEBUG
 #ifdef DEBUG
 #define info(fmt, ...)   {  \
 	logger_impl(LOG_INFO,  __FILE__, __LINE__, fmt, ##__VA_ARGS__); \


### PR DESCRIPTION
1. make sure setting.cnt initialized with int 0.
2. when setting.cnt ==0 do not enter logrotate，or it will generate empty log file.
3. if the rename operation fails , release the lock, or the program will not exit.